### PR TITLE
Add exercises API and front-end component

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { BrowserRouter, Routes, Route, Link, useParams } from "react-router-dom";
 import axios from "axios";
+import Exercises from "./Exercises";
 import "./App.css";
 import WorkflowDesigner from "./WorkflowDesigner";
 import OnboardingTutorial from "./OnboardingTutorial";
@@ -481,6 +482,7 @@ const AppContent = () => {
           <Route path="/workflows" element={<WorkflowDesigner />} />
           <Route path="/agent/:agentType" element={<AgentTesterWrapper />} />
           <Route path="/agent/:agentType/info" element={<AgentInfoWrapper />} />
+          <Route path="/exercises/:chapter" element={<ExercisesWrapper />} />
         </Routes>
 
         {/* Footer */}
@@ -524,6 +526,11 @@ const AgentTesterWrapper = () => {
 const AgentInfoWrapper = () => {
   const { agentType } = useParams();
   return <AgentInfo agentType={agentType} />;
+};
+
+const ExercisesWrapper = () => {
+  const { chapter } = useParams();
+  return <Exercises chapter={chapter} />;
 };
 
 export default App;

--- a/frontend/src/Exercises.js
+++ b/frontend/src/Exercises.js
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from "react";
+import axios from "axios";
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+const Exercises = ({ chapter }) => {
+  const [exercises, setExercises] = useState([]);
+  const [answers, setAnswers] = useState({});
+  const [showSolutions, setShowSolutions] = useState({});
+
+  useEffect(() => {
+    const fetchExercises = async () => {
+      try {
+        const res = await axios.get(`${API}/exercises/${chapter}`);
+        setExercises(res.data.exercises || []);
+      } catch (err) {
+        console.error("Error fetching exercises", err);
+      }
+    };
+    fetchExercises();
+  }, [chapter]);
+
+  const handleAnswerChange = (index, value) => {
+    setAnswers({ ...answers, [index]: value });
+  };
+
+  const revealSolution = (index) => {
+    setShowSolutions({ ...showSolutions, [index]: true });
+  };
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-6">Exercises - Chapter {chapter}</h1>
+      {exercises.map((ex, idx) => (
+        <div key={idx} className="mb-6 p-4 border rounded-lg">
+          <p className="mb-2 font-medium">{ex.question}</p>
+          <input
+            type="text"
+            value={answers[idx] || ""}
+            onChange={(e) => handleAnswerChange(idx, e.target.value)}
+            className="w-full p-2 border rounded mb-2"
+          />
+          <button
+            onClick={() => revealSolution(idx)}
+            className="bg-blue-500 text-white px-3 py-1 rounded"
+          >
+            Show Solution
+          </button>
+          {showSolutions[idx] && (
+            <div className="mt-2 text-green-700">{ex.solution || ex.answer}</div>
+          )}
+        </div>
+      ))}
+      {exercises.length === 0 && (
+        <p>No exercises found for this chapter.</p>
+      )}
+    </div>
+  );
+};
+
+export default Exercises;


### PR DESCRIPTION
## Summary
- add MongoDB exercises collection and API endpoint to fetch exercises by chapter
- introduce React Exercises component with routing and answer reveal logic
- wire frontend routing for `/exercises/:chapter`

## Testing
- `pytest`
- `CI=true npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68919afc18b0832090d6aa6f120cf004

## Summary by Sourcery

Add exercises API and front-end component to fetch and display chapter-specific exercises with solution reveal

New Features:
- Add MongoDB exercises collection and GET /api/exercises/{chapter} endpoint
- Create React Exercises component with routing, fetching exercises, and answer reveal functionality