### PR TITLE
Add user achievements and points tracking

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -136,8 +136,74 @@ class WorkflowResponse(BaseModel):
     created_at: datetime = Field(default_factory=datetime.utcnow)
     completed_at: Optional[datetime] = None
 
+
+class Achievement(BaseModel):
+    name: str
+    icon: str
+    description: Optional[str] = None
+    awarded_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class UserAchievements(BaseModel):
+    user_id: str
+    achievements: List[Achievement] = Field(default_factory=list)
+
+
+class UserPoints(BaseModel):
+    user_id: str
+    points: int = 0
+
 # Agent Registry
 AGENT_REGISTRY = {}
+
+
+BADGE_THRESHOLDS = [
+    (100, {"name": "Bronze", "icon": "🥉"}),
+    (500, {"name": "Silver", "icon": "🥈"}),
+    (1000, {"name": "Gold", "icon": "🥇"}),
+]
+
+
+def extract_user_id(session_id: Optional[str]) -> Optional[str]:
+    if not session_id:
+        return None
+    if session_id.startswith("user_"):
+        return session_id[5:].rsplit("_", 1)[0]
+    return session_id
+
+
+async def award_points(user_id: Optional[str], points: int):
+    if not user_id:
+        return
+
+    points_doc = await db.user_points.find_one({"user_id": user_id})
+    if points_doc:
+        new_points = points_doc.get("points", 0) + points
+        await db.user_points.update_one(
+            {"user_id": user_id}, {"$set": {"points": new_points}}
+        )
+    else:
+        new_points = points
+        await db.user_points.insert_one(UserPoints(user_id=user_id, points=new_points).dict())
+
+    achievements_doc = await db.user_achievements.find_one({"user_id": user_id})
+    if achievements_doc:
+        achievements_list = achievements_doc.get("achievements", [])
+    else:
+        achievements_list = []
+        await db.user_achievements.insert_one(UserAchievements(user_id=user_id).dict())
+
+    updated = False
+    for threshold, badge in BADGE_THRESHOLDS:
+        if new_points >= threshold and not any(a.get("name") == badge["name"] for a in achievements_list):
+            achievements_list.append(badge)
+            updated = True
+
+    if updated:
+        await db.user_achievements.update_one(
+            {"user_id": user_id}, {"$set": {"achievements": achievements_list}}
+        )
+
 
 class BaseAgent:
     def __init__(self, agent_type: AgentType):
@@ -752,10 +818,15 @@ async def process_agent_request(request: AgentRequest):
     
     agent = AGENT_REGISTRY[request.agent_type]
     response = await agent.process(request.request, request.llm_provider)
-    
+
+    response_doc = response.dict()
+    if request.session_id:
+        response_doc["session_id"] = request.session_id
+        await award_points(extract_user_id(request.session_id), 10)
+
     # Store in database
-    await db.agent_responses.insert_one(response.dict())
-    
+    await db.agent_responses.insert_one(response_doc)
+
     return response
 
 @api_router.get("/agents/{agent_type}")
@@ -778,6 +849,18 @@ async def get_session_history(session_id: str):
     # Serialize to handle ObjectId
     responses = [serialize_doc(response) for response in responses]
     return {"session_id": session_id, "responses": responses}
+
+
+@api_router.get("/users/{user_id}/profile")
+async def get_user_profile(user_id: str):
+    """Get user points and achievements"""
+    points_doc = await db.user_points.find_one({"user_id": user_id}) or {}
+    achievements_doc = await db.user_achievements.find_one({"user_id": user_id}) or {}
+    return {
+        "user_id": user_id,
+        "points": points_doc.get("points", 0),
+        "achievements": achievements_doc.get("achievements", []),
+    }
 
 # Workflow API Endpoints
 @api_router.post("/workflows")
@@ -818,6 +901,8 @@ async def execute_workflow_task(workflow_id: str):
         workflow = await WORKFLOW_ENGINE.execute_workflow(workflow_id)
         # Update in database
         await db.workflows.replace_one({"id": workflow_id}, workflow.dict())
+        if workflow.session_id:
+            await award_points(extract_user_id(workflow.session_id), 50)
         logger.info(f"Workflow {workflow_id} completed")
     except Exception as e:
         logger.error(f"Workflow {workflow_id} failed: {str(e)}")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,6 +6,7 @@ import WorkflowDesigner from "./WorkflowDesigner";
 import OnboardingTutorial from "./OnboardingTutorial";
 import { AuthProvider, useAuth } from "./AuthContext";
 import LoginModal from "./LoginModal";
+import Profile from "./Profile";
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 const API = `${BACKEND_URL}/api`;
@@ -458,6 +459,11 @@ const AppContent = () => {
                   Tutorial
                 </button>
                 {isAuthenticated && (
+                  <Link to="/profile" className="text-gray-600 hover:text-gray-800">
+                    Profile
+                  </Link>
+                )}
+                {isAuthenticated && (
                   <div className="flex items-center space-x-4">
                     <span className="text-sm text-gray-600 dark:text-gray-300">
                       {user?.username}
@@ -481,6 +487,7 @@ const AppContent = () => {
           <Route path="/workflows" element={<WorkflowDesigner />} />
           <Route path="/agent/:agentType" element={<AgentTesterWrapper />} />
           <Route path="/agent/:agentType/info" element={<AgentInfoWrapper />} />
+          <Route path="/profile" element={<Profile />} />
         </Routes>
 
         {/* Footer */}

--- a/frontend/src/Profile.js
+++ b/frontend/src/Profile.js
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { useAuth } from './AuthContext';
+
+const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
+const API = `${BACKEND_URL}/api`;
+
+const Profile = () => {
+  const { user, isAuthenticated } = useAuth();
+  const [profile, setProfile] = useState({ points: 0, achievements: [] });
+
+  useEffect(() => {
+    const fetchProfile = async () => {
+      if (!user) return;
+      try {
+        const res = await axios.get(`${API}/users/${user.id}/profile`);
+        setProfile(res.data);
+      } catch (err) {
+        console.error('Error fetching profile:', err);
+      }
+    };
+    fetchProfile();
+  }, [user]);
+
+  if (!isAuthenticated) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <p>Please sign in to view your profile.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <h1 className="text-3xl font-bold mb-4">Profile</h1>
+      <p className="mb-4">Points: {profile.points}</p>
+      <h2 className="text-2xl font-semibold mb-2">Achievements</h2>
+      <div className="flex space-x-4">
+        {profile.achievements.length > 0 ? (
+          profile.achievements.map((ach, index) => (
+            <div key={index} className="text-center">
+              <div className="text-4xl">{ach.icon}</div>
+              <div className="text-sm mt-1">{ach.name}</div>
+            </div>
+          ))
+        ) : (
+          <p>No achievements yet.</p>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Profile;


### PR DESCRIPTION
## Summary
- add Pydantic models and helpers to track user points and badge achievements
- award progress points when agents process requests or workflows complete
- introduce profile page showing accumulated points and badges

## Testing
- `pytest`
- `CI=true npm test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68919b3d322c8320b6e3a4c8b20223e8

## Summary by Sourcery

Introduce user points and achievements system with backend tracking and frontend profile display

New Features:
- Add Pydantic models and DB collections for user points and achievements
- Award points to users for agent requests and workflow completions and assign badge achievements based on thresholds
- Expose a user profile API endpoint returning accumulated points and achievements
- Add a Profile page in the frontend with navigation link to display user points and badges

Enhancements:
- Extract session-based user IDs for accurate points attribution
- Include session_id in stored agent responses for linking actions to users