### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -440,11 +440,11 @@ const AppContent = () => {
         {/* Header */}
         <header className="bg-white/70 dark:bg-gray-800/50 backdrop-blur-md shadow-sm">
           <div className="container mx-auto px-4 py-4">
-            <div className="flex justify-between items-center">
-              <Link to="/" className="text-xl font-bold text-gray-800 dark:text-gray-100">
+            <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center">
+              <Link to="/" className="text-xl font-bold text-gray-800 dark:text-gray-100 mb-4 sm:mb-0">
                 Prompt-This - Prompt Engineering Agent Platform
               </Link>
-              <nav className="flex items-center space-x-6">
+              <nav className="flex flex-col sm:flex-row items-center sm:justify-end gap-2 sm:gap-6">
                 <Link to="/" className="text-gray-600 hover:text-gray-800">
                   Agents
                 </Link>
@@ -458,7 +458,7 @@ const AppContent = () => {
                   Tutorial
                 </button>
                 {isAuthenticated && (
-                  <div className="flex items-center space-x-4">
+                  <div className="flex flex-col sm:flex-row items-center gap-2 sm:gap-4">
                     <span className="text-sm text-gray-600 dark:text-gray-300">
                       {user?.username}
                     </span>

--- a/frontend/src/LoginModal.js
+++ b/frontend/src/LoginModal.js
@@ -1,3 +1,4 @@
+
 import React, { useState } from 'react';
 import { useAuth } from './AuthContext';
 
@@ -22,9 +23,9 @@ const LoginModal = ({ isOpen, onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="glass rounded-lg shadow-xl max-w-md w-full p-6">
-        <h2 className="text-2xl font-bold text-gray-800 mb-4">Welcome to Prompt-This!</h2>
-        <p className="text-gray-600 mb-6">
+      <div className="glass rounded-lg shadow-xl max-w-md w-full p-4 sm:p-6">
+        <h2 className="text-xl sm:text-2xl font-bold text-gray-800 mb-4">Welcome to Prompt-This!</h2>
+        <p className="text-sm sm:text-base text-gray-600 mb-6">
           To save your workflows and track your progress, please choose how you'd like to continue:
         </p>
 
@@ -37,7 +38,7 @@ const LoginModal = ({ isOpen, onClose }) => {
               type="text"
               value={username}
               onChange={(e) => setUsername(e.target.value)}
-              className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              className="w-full p-2 sm:p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="Enter your name..."
             />
           </div>
@@ -46,15 +47,15 @@ const LoginModal = ({ isOpen, onClose }) => {
             <button
               type="submit"
               disabled={!username.trim()}
-              className="w-full bg-blue-500 text-white py-3 px-4 rounded-lg hover:bg-blue-600 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
+              className="w-full bg-blue-500 text-white py-2 sm:py-3 px-4 rounded-lg hover:bg-blue-600 disabled:bg-gray-400 disabled:cursor-not-allowed transition-colors"
             >
               Continue as "{username || 'Your Name'}"
             </button>
-            
+
             <button
               type="button"
               onClick={handleQuickLogin}
-              className="w-full bg-gray-500 text-white py-3 px-4 rounded-lg hover:bg-gray-600 transition-colors"
+              className="w-full bg-gray-500 text-white py-2 sm:py-3 px-4 rounded-lg hover:bg-gray-600 transition-colors"
             >
               Continue as Guest
             </button>

--- a/frontend/src/WorkflowDesigner.js
+++ b/frontend/src/WorkflowDesigner.js
@@ -224,13 +224,13 @@ Refresh this page in a few seconds to see progress!`);
   };
 
   return (
-    <div className="container mx-auto px-4 py-8">
+    <div className="container mx-auto px-2 py-4 sm:px-4 sm:py-8">
       <h1 className="text-3xl font-bold text-gray-800 mb-8">Workflow Orchestration</h1>
 
       {/* Tab Navigation */}
       <div className="mb-6">
         <div className="border-b border-gray-200">
-          <nav className="-mb-px flex space-x-8">
+          <nav className="-mb-px flex flex-wrap gap-4 sm:gap-8">
             <button
               onClick={() => setActiveTab("designer")}
               className={`py-2 px-1 border-b-2 font-medium text-sm ${
@@ -267,13 +267,13 @@ Refresh this page in a few seconds to see progress!`);
 
       {/* Designer Tab */}
       {activeTab === "designer" && (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8">
           {/* Workflow Configuration */}
           <div className="lg:col-span-2">
             <div className="glass rounded-lg shadow-md p-6">
-              <div className="flex justify-between items-center mb-6">
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-center mb-6 gap-4">
                 <h2 className="text-xl font-semibold">Workflow Designer</h2>
-                <div className="space-x-2">
+                <div className="flex flex-col sm:flex-row gap-2">
                   <button
                     onClick={resetWorkflow}
                     className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600"
@@ -504,14 +504,14 @@ Refresh this page in a few seconds to see progress!`);
           )}
 
           {workflows.map(workflow => (
-            <div key={workflow.id} className="glass rounded-lg shadow-md p-6">
-              <div className="flex justify-between items-start">
+            <div key={workflow.id} className="glass rounded-lg shadow-md p-4 sm:p-6">
+              <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-4">
                 <div>
                   <h3 className="text-xl font-semibold">{workflow.name}</h3>
                   {workflow.description && (
                     <p className="text-gray-600 mt-1">{workflow.description}</p>
                   )}
-                  <div className="mt-2 flex items-center space-x-4">
+                  <div className="mt-2 flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
                     <span className="text-sm text-gray-500">
                       {workflow.steps?.length || 0} steps
                     </span>
@@ -528,7 +528,7 @@ Refresh this page in a few seconds to see progress!`);
                     </span>
                   </div>
                 </div>
-                <div className="space-x-2">
+                <div className="flex flex-col sm:flex-row gap-2">
                   <button
                     onClick={() => executeWorkflow(workflow.id)}
                     disabled={loading || workflow.status === 'running'}


### PR DESCRIPTION
## Summary
- make login modal responsive with smaller text and padding on mobile
- stack header navigation and reduce spacing on small screens
- rework workflow designer layout to wrap controls and lists for mobile viewports

## Testing
- `npm test --prefix frontend -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68919b42c73c832092ab552319c7b18c