### PR TITLE
fix: remove duplicate Path import in server module

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -13,7 +13,6 @@ from enum import Enum
 import asyncio
 import json
 import sys
-from pathlib import Path
 
 # Add the backend directory to Python path
 sys.path.append(str(Path(__file__).parent))


### PR DESCRIPTION
## Summary
- remove redundant Path import from backend server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68947e5ad9548320b972e519fa58aaa5